### PR TITLE
Add Locker Image Count to Capsule Tracking table

### DIFF
--- a/hora-new-admin-dashboard/src/app/dashboard/capsule-tracking/page.jsx
+++ b/hora-new-admin-dashboard/src/app/dashboard/capsule-tracking/page.jsx
@@ -136,6 +136,7 @@ const Capsuletracking = () => {
                   <th>Total Image Shared</th>
                   <th>Capsule Share Count</th>
                   <th>Total Registered users</th>
+                  <th>Locker Image Count</th>
                   <th>Times link opened</th>
                   <th>Face Counts</th>
                   <th>First Device Type</th>
@@ -193,6 +194,7 @@ const Capsuletracking = () => {
                         <td>{order?.counts?.totalShares || 0}</td>
                         <td>{order?.counts?.shareCapsuleClicks || 0}</td>
                         <td>{order?.counts?.totalViews || 0}</td>
+                        <td>{order?.counts?.lockerImageCount || 0}</td>
                         <td>{order?.counts?.totalClicks || 0}</td>
                         <td>{order?.counts?.totalPersonCount || 0}</td>
                         <td>{order?.counts?.firstDeviceType || "-"}</td>


### PR DESCRIPTION
<img width="334" height="637" alt="Screenshot 2026-06-15 at 7 02 03 PM" src="https://github.com/user-attachments/assets/8ba84a5e-6a1b-4c5c-97de-79328b75e07f" />
